### PR TITLE
boot2: derive keyY as twl boot9 does, add support for ntrboot images

### DIFF
--- a/dsi.c
+++ b/dsi.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include "polarssl/rsa.h"
+
 void dsi_set_key( dsi_context* ctx,
 				 unsigned char key[16] )
 {
@@ -370,4 +372,13 @@ void dsi_es_encrypt( dsi_es_context* ctx,
 
 	memcpy(metablock, mac, 16);
 
+}
+
+void dsi_rsa_signature_decrypt(const char * modulus, const unsigned char* signature, unsigned char* message) {
+	rsa_context rsa;
+	rsa_init(&rsa, RSA_PKCS_V15, 0);
+	rsa.len = 128;
+	mpi_read_string(&rsa.N, 16, modulus);
+	mpi_read_string(&rsa.E, 16, "10001");
+	rsa_public(&rsa, signature, message);
 }

--- a/dsi.h
+++ b/dsi.h
@@ -97,6 +97,8 @@ void		dsi_es_encrypt( dsi_es_context* ctx,
 						    unsigned char metablock[32],
 							unsigned int size );
 
+void dsi_rsa_signature_decrypt(const char * modulus, const unsigned char* signature, unsigned char* message);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Adds support for obtaining the bootloader image keyY from the RSA signature message as TWL boot9 does. For NAND/SPI it tries NAND pubkey, and then SPI if the NAND pubkey doesn't work.
- Adds support for decrypting TWL ntrboot images, these have the RSA signature at offset 0x100 and have the ARM7/ARM9 image descriptors at the same offset as a regular DS cart.